### PR TITLE
Add Sunbeam event theme

### DIFF
--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -35,7 +35,7 @@ export const defaultThemes: Record<string, Omit<EventTheme, 'logo'>> = {
 	sunbeam: {
 		background: '/sunbeam-background.webp',
 		font: '"Galindo", sans-serif',
-		primary: '#f9a636',
+		primary: '#0e387a',
 		selected: '#F59E0B'
 	}
 };


### PR DESCRIPTION
## Summary
- Adds "sunbeam" as a per-event theme preset alongside campfire, flagship, and sleepover (logo, background, font, and colors sourced from the Sunbeam app).
- Fixes the primary color's contrast: the initial bright orange (`#f9a636`) was nearly unreadable against the white/amber text rendered on top of it everywhere in the app (1.99:1 and 1.08:1 contrast ratios). Swapped to Sunbeam's own navy ink color (`#0e387a`), giving 11.26:1 and 5.24:1 respectively.

## Test plan
- [ ] Create/edit an event with theme "Sunbeam" via `/admin/events/create` or `/admin/events/[id]/theme`
- [ ] Verify the event landing page, vote page, and project pages render with legible white text on the navy primary fill
- [ ] Verify the logo and background image load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)